### PR TITLE
Fix YAML errors in sample workflow

### DIFF
--- a/config.d/realm.tpl/workflow/def/crl_issuance.yaml
+++ b/config.d/realm.tpl/workflow/def/crl_issuance.yaml
@@ -106,10 +106,6 @@ condition:
           test: $context->{ca_alias}
 
 field:
-    ca_alias:
-        name: ca_alias
-        type: text
-
     force_issue:
         label: I18N_OPENXPKI_UI_WORKFLOW_FIELD_FORCE_ISSUE_LABEL
         name: force_issue

--- a/config.d/realm.tpl/workflow/global/action/nice_fetch_private_key.yaml
+++ b/config.d/realm.tpl/workflow/global/action/nice_fetch_private_key.yaml
@@ -5,3 +5,4 @@ param:
     _map_key_id: "[% USE Certificate; Certificate.key_id(context.cert_identifier) %]"
     _map_password: $_password
     target_key: _private_key 
+


### PR DESCRIPTION
Two small issues in the default workflow config

- The first is a missing new line at the end of a file
- The second is a duplicated attribute (ca_alias)

Both prevent openxpki to parse the config, and to start properly