### PR TITLE
Fix issue with database initialization for mysql

### DIFF
--- a/contrib/sql/schema-mysql.sql
+++ b/contrib/sql/schema-mysql.sql
@@ -1,6 +1,11 @@
 SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
 SET time_zone = "+00:00";
 
+
+CREATE DATABASE IF NOT EXISTS `openxpki`;
+
+USE openxpki;
+
 CREATE TABLE IF NOT EXISTS `aliases` (
   `identifier` varchar(64) DEFAULT NULL,
   `pki_realm` varchar(255) NOT NULL,


### PR DESCRIPTION
docker-compose fails to bring up the server instance as it is unable to find required tables in the database openxpki.
Making sure the database is created if not there yet, and also indicating that we want to use this database for subsequent table operations fixes this issue.