### PR TITLE
Add keyUsage to v3_scep_extensions in sampleconfig.sh

### DIFF
--- a/contrib/sampleconfig.sh
+++ b/contrib/sampleconfig.sh
@@ -209,6 +209,7 @@ authorityKeyIdentifier  = keyid:always,issuer
 
 [ v3_scep_extensions ]
 subjectKeyIdentifier    = hash
+keyUsage                = digitalSignature, keyEncipherment
 basicConstraints        = CA:FALSE
 authorityKeyIdentifier  = keyid,issuer
 


### PR DESCRIPTION
`sampleconfig.sh` now creates SCEP service certificate with **keyUsage**.
```
keyUsage                = digitalSignature, keyEncipherment
```

Closes #14 
