### PR TITLE
Fixed syntax error in Pgsql schema

### DIFF
--- a/contrib/sql/schema-psql.sql
+++ b/contrib/sql/schema-psql.sql
@@ -88,7 +88,7 @@ CREATE TABLE certificate (
     hold_instruction_code text,
     revocation_id numeric(49,0),
     req_key numeric(49,0),
-    data text,
+    data text
 );
 
 --


### PR DESCRIPTION
At line 91 of the schema-pgsql.sql file is a trailing comma that wasn't removed.
It is the last field of the table, so it mustn't have a comma after the type.

This pull requests removes it.