### PR TITLE
Addresses problems with logrotate permissions

### DIFF
--- a/contrib/logrotate.conf
+++ b/contrib/logrotate.conf
@@ -4,9 +4,11 @@
 /var/log/openxpki/connector.log
 /var/log/openxpki/workflows.log
 /var/log/openxpki/stderr.log {
+    create 0640 openxpki openxpki
     daily
     rotate 10
     missingok
+    compress
     delaycompress
     su openxpki openxpki
     notifempty
@@ -18,13 +20,13 @@
 /var/log/openxpki/soap.log
 /var/log/openxpki/webui.log
 /var/log/openxpki/est.log {
+    create 0640 www-data openxpki
     daily
     rotate 10
     missingok
+    compress
     delaycompress
-    # if you decide to have apache in the openxpki group and have the
-    # log directory owned by it, you need to change this here, too!
-    su www-data www-data
+    su www-data openxpki
     notifempty
     dateext
 }


### PR DESCRIPTION
closes openxpki/openxpki#848

Due to suid-group-bit on the log directory the `su` settings won't work correclty and logrotate can't rotate the logfiles correctly

Additional ideas about rotating the `audit.log` are documented in the ticket mentioned above.