### PR TITLE
Set tls_server DN from DNS SAN if CN is missing

### DIFF
--- a/config.d/realm.tpl/profile/tls_server.yaml
+++ b/config.d/realm.tpl/profile/tls_server.yaml
@@ -71,7 +71,7 @@ style:
 
     enroll:
         subject:
-            dn: CN=[% CN.0 %],DC=Test Deployment,DC=OpenXPKI,DC=org
+            dn: [% IF CN.0 && CN.0 != '' %]CN=[% CN.0 %][% ELSE %]CN=[% SAN_DNS.0 %][% END %],DC=Test Deployment,DC=OpenXPKI,DC=org
             san:
                 dns: "[% FOREACH entry = SAN_DNS %][% entry.lower %] | [% END %]"
                 ip : "[% FOREACH entry = SAN_IP %][% entry %] | [% END %]"


### PR DESCRIPTION
Some clients (SCEP / RPC) do not set cert CN. In that case, fallback to the first DNS SAN instead.