### PR TITLE
Fixes incomplete SCEP Configuration

### DIFF
--- a/client.d/service/scep/generic.yaml
+++ b/client.d/service/scep/generic.yaml
@@ -26,7 +26,10 @@ PKIOperation:
     input:
      - signature
     pickup:
-        namespace: transaction_id
+        workflow: check_enrollment
+        input:
+          - pkcs10
+          - transaction_id
     # Support endpoint expansion for PKIOperation
     env:
      - server


### PR DESCRIPTION
This PR fixes an issue where pending scep requests (PENDING workflow state) will not get picked up again because the workflow can't be found using the transaction_id in datapool.namespace. The configuration is obviously missing the link to check_workflow that's present in the RPC workflow.

This fixes [#944](https://github.com/openxpki/openxpki/issues/944)

